### PR TITLE
Client ignores FHIR response errors

### DIFF
--- a/pkg/fhir/processor.go
+++ b/pkg/fhir/processor.go
@@ -23,6 +23,16 @@ func NewProcessor(config config.Fhir) *Processor {
 
 func (p *Processor) ProcessMessage(msg *kafka.Message) bool {
 
+	if msg.Value == nil || len(msg.Value) == 0 {
+		// tombstone record
+		log.Warn().
+			Str("topic", *msg.TopicPartition.Topic).
+			Str("key", string(msg.Key)).
+			Str("offset", msg.TopicPartition.Offset.String()).
+			Msg("Tombstone record encountered. Message ignored")
+		return true
+	}
+
 	// filter
 	if p.filter != nil && !p.filter.apply(msg.Value) {
 		// filtered, don't send but mark processed


### PR DESCRIPTION
The FHIR client currently marks messages as successfully prcoessed if the HTTP response code shows success (i.e. 2xx).

However, the status of processing individual entities (resources) are returned by the FHIR server via separate Bundle response entries. Those should be handled, too.